### PR TITLE
Fixes Error- When video is played again after finishing

### DIFF
--- a/lib/widgets/VideoPlayerWidget.dart
+++ b/lib/widgets/VideoPlayerWidget.dart
@@ -80,6 +80,11 @@ class _VideoPlayerWidgetState extends State<VideoPlayerWidget> {
                     ),
                     onPressed: () {
                       setState(() {
+                        if (videoPlayerController.value.buffered.length != 0 &&
+                            videoPlayerController.value.position ==
+                                videoPlayerController.value.buffered[0].end) {
+                          videoPlayerController.seekTo(Duration(seconds: 0));
+                        }
                         videoPlayerController.value.isPlaying
                             ? videoPlayerController.pause()
                             : videoPlayerController.play();


### PR DESCRIPTION
This resets the position is video player controller to 0.
When video is played again and the position is still at end of the video.