### PR TITLE
Fix previous messages pagination query. Update flutter_bloc and cached_network_image

### DIFF
--- a/lib/blocs/authentication/AuthenticationBloc.dart
+++ b/lib/blocs/authentication/AuthenticationBloc.dart
@@ -65,7 +65,7 @@ class AuthenticationBloc
           yield ProfileUpdated();
         } else {
           yield Authenticated(user); // else yield the authenticated state and redirect to profile page to complete profile.
-          dispatch(LoggedIn(user)); // also disptach a login event so that the data from gauth can be prefilled
+          add(LoggedIn(user)); // also disptach a login event so that the data from gauth can be prefilled
         }
       } else {
         yield UnAuthenticated(); // is not signed in then show the home page
@@ -88,7 +88,7 @@ class AuthenticationBloc
         yield ProfileUpdated(); //if profile is complete go to home page
       } else {
         yield Authenticated(firebaseUser); // else yield the authenticated state and redirect to profile page to complete profile.
-        dispatch(LoggedIn(firebaseUser)); // also dispatch a login event so that the data from gauth can be prefilled
+        add(LoggedIn(firebaseUser)); // also dispatch a login event so that the data from gauth can be prefilled
       }
     } catch (_, stacktrace) {
       print(stacktrace);

--- a/lib/blocs/chats/ChatBloc.dart
+++ b/lib/blocs/chats/ChatBloc.dart
@@ -87,7 +87,7 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
       chatsSubscription?.cancel();
       chatsSubscription = chatRepository
           .getChats()
-          .listen((chats) => dispatch(ReceivedChatsEvent(chats)));
+          .listen((chats) => add(ReceivedChatsEvent(chats)));
     } on MessioException catch (exception) {
       print(exception.errorMessage());
       yield ErrorState(exception);
@@ -104,7 +104,7 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
       //  print('MessSubMap: $messagesSubscriptionMap');
       StreamSubscription messagesSubscription = messagesSubscriptionMap[chatId];
       messagesSubscription?.cancel();
-      messagesSubscription = chatRepository.getMessages(chatId).listen((messages) => dispatch(ReceivedMessagesEvent(messages, event.chat.username)));
+      messagesSubscription = chatRepository.getMessages(chatId).listen((messages) => add(ReceivedMessagesEvent(messages, event.chat.username)));
 
       messagesSubscriptionMap[chatId] = messagesSubscription;
     } on MessioException catch (exception) {
@@ -133,7 +133,7 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     print('fetching details fro ${event.chat.username}');
     User user = await userDataRepository.getUser(event.chat.username);
     yield FetchedContactDetailsState(user, event.chat.username);
-    dispatch(FetchMessagesEvent(event.chat));
+    add(FetchMessagesEvent(event.chat));
   }
 
   Future mapSendAttachmentEventToState(SendAttachmentEvent event) async {
@@ -160,6 +160,6 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
   @override
   void dispose() {
     messagesSubscriptionMap.forEach((_, subscription) => subscription.cancel());
-    super.dispose();
+    super.close();
   }
 }

--- a/lib/blocs/contacts/ContactsBloc.dart
+++ b/lib/blocs/contacts/ContactsBloc.dart
@@ -28,7 +28,7 @@ class ContactsBloc extends Bloc<ContactsEvent, ContactsState> {
         subscription?.cancel();
         subscription = userDataRepository.getContacts().listen((contacts) => {
               print('dispatching $contacts'),
-              dispatch(ReceivedContactsEvent(contacts))
+              add(ReceivedContactsEvent(contacts))
             });
       } on MessioException catch (exception) {
         print(exception.errorMessage());
@@ -51,7 +51,7 @@ class ContactsBloc extends Bloc<ContactsEvent, ContactsState> {
       subscription?.cancel();
       subscription = userDataRepository.getContacts().listen((contacts) => {
             print('dispatching $contacts'),
-            dispatch(ReceivedContactsEvent(contacts))
+            add(ReceivedContactsEvent(contacts))
           });
     } on MessioException catch (exception) {
       print(exception.errorMessage());
@@ -75,6 +75,6 @@ class ContactsBloc extends Bloc<ContactsEvent, ContactsState> {
   @override
   void dispose() {
     subscription.cancel();
-    super.dispose();
+    super.close();
   }
 }

--- a/lib/blocs/home/HomeBloc.dart
+++ b/lib/blocs/home/HomeBloc.dart
@@ -18,7 +18,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     if (event is FetchHomeChatsEvent) {
       yield FetchingHomeChatsState();
       chatRepository.getConversations().listen(
-            (conversations) => dispatch(ReceivedChatsEvent(conversations)));
+            (conversations) => add(ReceivedChatsEvent(conversations)));
     }
     if (event is ReceivedChatsEvent) {
       yield FetchingHomeChatsState();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,31 +30,31 @@ void main() async {
   runApp(MultiBlocProvider(
     providers: [
       BlocProvider<AuthenticationBloc>(
-        builder: (context) => AuthenticationBloc(
+        create: (context) => AuthenticationBloc(
             authenticationRepository: authRepository,
             userDataRepository: userDataRepository,
             storageRepository: storageRepository)
-          ..dispatch(AppLaunched()),
+          ..add(AppLaunched()),
       ),
       BlocProvider<ContactsBloc>(
-        builder: (context) => ContactsBloc(
+        create: (context) => ContactsBloc(
             userDataRepository: userDataRepository,
             chatRepository: chatRepository),
       ),
       BlocProvider<ChatBloc>(
-        builder: (context) => ChatBloc(
+        create: (context) => ChatBloc(
             userDataRepository: userDataRepository,
             storageRepository: storageRepository,
             chatRepository: chatRepository),
       ),
       BlocProvider<AttachmentsBloc>(
-        builder: (context) => AttachmentsBloc(chatRepository: chatRepository),
+        create: (context) => AttachmentsBloc(chatRepository: chatRepository),
       ),
       BlocProvider<HomeBloc>(
-        builder: (context) => HomeBloc(chatRepository: chatRepository),
+        create: (context) => HomeBloc(chatRepository: chatRepository),
       ),
       BlocProvider<ConfigBloc>(
-        builder: (context) => ConfigBloc(storageRepository: storageRepository,userDataRepository: userDataRepository),
+        create: (context) => ConfigBloc(storageRepository: storageRepository,userDataRepository: userDataRepository),
       )
     ],
     child: Messio(),
@@ -97,7 +97,7 @@ class _MessioState extends State<Messio> {
               return RegisterPage();
             } else if (state is ProfileUpdated) {
               if(SharedObjects.prefs.getBool(Constants.configMessagePaging))
-                BlocProvider.of<ChatBloc>(context).dispatch(FetchChatListEvent());
+                BlocProvider.of<ChatBloc>(context).add(FetchChatListEvent());
               return HomePage();
             } else {
               return RegisterPage();

--- a/lib/pages/AttachmentPage.dart
+++ b/lib/pages/AttachmentPage.dart
@@ -46,13 +46,13 @@ class _AttachmentPageState extends State<AttachmentPage>
     tabController.addListener(() {
       int index = tabController.index;
       if (index == 0 && photos == null) // if photos are not initialized and we're on the first tab then trigger a fetch event for photos
-        attachmentsBloc.dispatch(FetchAttachmentsEvent(chatId, FileType.IMAGE));
+        attachmentsBloc.add(FetchAttachmentsEvent(chatId, FileType.IMAGE));
       else if (index == 1 && videos == null) // if videos are not initialized and we're on the second tab then  trigger a fetch event for videos
-        attachmentsBloc.dispatch(FetchAttachmentsEvent(chatId, FileType.VIDEO));
+        attachmentsBloc.add(FetchAttachmentsEvent(chatId, FileType.VIDEO));
       else if (index == 2 && files == null) //if files are not initialized and we're on the third tab then trigger a fetch event for files
-        attachmentsBloc.dispatch(FetchAttachmentsEvent(chatId, FileType.ANY));
+        attachmentsBloc.add(FetchAttachmentsEvent(chatId, FileType.ANY));
     });
-    attachmentsBloc.dispatch(FetchAttachmentsEvent(chatId, initialFileType)); // triggers at the very start.
+    attachmentsBloc.add(FetchAttachmentsEvent(chatId, initialFileType)); // triggers at the very start.
   }
 
   @override

--- a/lib/pages/ContactListPage.dart
+++ b/lib/pages/ContactListPage.dart
@@ -43,7 +43,7 @@ class _ContactListPageState extends State<ContactListPage>
       curve: Curves.linear,
     );
     animationController.forward();
-    contactsBloc.dispatch(FetchContactsEvent());
+    contactsBloc.add(FetchContactsEvent());
     super.initState();
   }
 
@@ -185,7 +185,7 @@ class _ContactListPageState extends State<ContactListPage>
                                     elevation: 0.0,
                                     child: getButtonChild(state),
                                     onPressed: () {
-                                      contactsBloc.dispatch(AddContactEvent(
+                                      contactsBloc.add(AddContactEvent(
                                           username: usernameController.text));
                                     },
                                   );

--- a/lib/pages/ConversationPage.dart
+++ b/lib/pages/ConversationPage.dart
@@ -32,7 +32,7 @@ class _ConversationPageState extends State<ConversationPage> with AutomaticKeepA
     if(contact!=null)
       chat = Chat(contact.username,contact.chatId);
     chatBloc = BlocProvider.of<ChatBloc>(context);
-    chatBloc.dispatch(FetchConversationDetailsEvent(chat));
+    chatBloc.add(FetchConversationDetailsEvent(chat));
      }
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/ConversationPageSlide.dart
+++ b/lib/pages/ConversationPageSlide.dart
@@ -54,7 +54,7 @@ class _ConversationPageSlideState extends State<ConversationPageSlide>
                           for (int i = 0; i < chatList.length; i++) {
                             if (startContact.username == chatList[i].username) {
                               BlocProvider.of<ChatBloc>(context)
-                                  .dispatch(PageChangedEvent(i, chatList[i]));
+                                  .add(PageChangedEvent(i, chatList[i]));
                               pageController.jumpToPage(i);
                             }
                           }
@@ -68,7 +68,7 @@ class _ConversationPageSlideState extends State<ConversationPageSlide>
                               controller: pageController,
                               itemCount: chatList.length,
                               onPageChanged: (index) =>
-                                  BlocProvider.of<ChatBloc>(context).dispatch(
+                                  BlocProvider.of<ChatBloc>(context).add(
                                       PageChangedEvent(index, chatList[index])),
                               itemBuilder: (bc, index) =>
                                   ConversationPage(chat:chatList[index]));

--- a/lib/pages/HomePage.dart
+++ b/lib/pages/HomePage.dart
@@ -21,7 +21,7 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     homeBloc = BlocProvider.of<HomeBloc>(context);
-    homeBloc.dispatch(FetchHomeChatsEvent());
+    homeBloc.add(FetchHomeChatsEvent());
     super.initState();
   }
 

--- a/lib/pages/RegisterPage.dart
+++ b/lib/pages/RegisterPage.dart
@@ -20,7 +20,6 @@ class RegisterPage extends StatefulWidget {
 
   @override
   State<StatefulWidget> createState() {
-    // TODO: implement createState
     return _RegisterPageState();
   }
 }
@@ -93,7 +92,7 @@ class _RegisterPageState extends State<RegisterPage>
       });
     });
     authenticationBloc = BlocProvider.of<AuthenticationBloc>(context);
-    authenticationBloc.state.listen((state) {
+    authenticationBloc.listen((state) {
       if (state is Authenticated) {
         updatePageState(1);
       }
@@ -202,7 +201,7 @@ class _RegisterPageState extends State<RegisterPage>
         margin: EdgeInsets.only(top: 100),
         child: FlatButton.icon(
             onPressed: () => BlocProvider.of<AuthenticationBloc>(context)
-                .dispatch(ClickedGoogleLogin()),
+                .add(ClickedGoogleLogin()),
             color: Colors.transparent,
             icon: Image.asset(
               Assets.google_button,
@@ -337,7 +336,7 @@ class _RegisterPageState extends State<RegisterPage>
 
   Future pickImage() async {
     profileImageFile = await ImagePicker.pickImage(source: ImageSource.gallery);
-    authenticationBloc.dispatch(PickedProfilePicture(profileImageFile));
+    authenticationBloc.add(PickedProfilePicture(profileImageFile));
   }
 
   Future<bool> onWillPop() async {
@@ -409,7 +408,7 @@ class _RegisterPageState extends State<RegisterPage>
                         age != null &&
                         usernameController.text.isNotEmpty)
                       {
-                        authenticationBloc.dispatch(SaveProfile(
+                        authenticationBloc.add(SaveProfile(
                             profileImageFile, age, usernameController.text))
                       }
                     else

--- a/lib/pages/SettingsPage.dart
+++ b/lib/pages/SettingsPage.dart
@@ -185,7 +185,7 @@ class _SettingsPageState extends State<SettingsPage> {
                                 ),
                                 Switch(
                                   value: configImageCompression,
-                                  onChanged: (value) => configBloc.dispatch(
+                                  onChanged: (value) => configBloc.add(
                                       ConfigValueChanged(
                                           Constants.configImageCompression,
                                           value)),
@@ -214,7 +214,7 @@ class _SettingsPageState extends State<SettingsPage> {
                                 ),
                                 Switch(
                                   value: configMessagesPeek,
-                                  onChanged: (value) => configBloc.dispatch(
+                                  onChanged: (value) => configBloc.add(
                                       ConfigValueChanged(
                                           Constants.configMessagePeek, value)),
                                 ),
@@ -242,7 +242,7 @@ class _SettingsPageState extends State<SettingsPage> {
                                 ),
                                 Switch(
                                   value: configMessagePaging,
-                                  onChanged: (value) => configBloc.dispatch(
+                                  onChanged: (value) => configBloc.add(
                                       ConfigValueChanged(
                                           Constants.configMessagePaging,
                                           value)),
@@ -270,7 +270,7 @@ class _SettingsPageState extends State<SettingsPage> {
                                     ]),
                                 Switch(
                                   value: configDarkMode,
-                                  onChanged: (value) => configBloc.dispatch(
+                                  onChanged: (value) => configBloc.add(
                                       ConfigValueChanged(
                                           Constants.configDarkMode, value)),
                                 ),
@@ -296,8 +296,8 @@ class _SettingsPageState extends State<SettingsPage> {
                         'SIGN OUT',
                         style: Theme.of(context).textTheme.button,
                       ),
-                      onPressed: ()  => {BlocProvider.of<AuthenticationBloc>(context).dispatch(ClickedLogout()),
-                      configBloc.dispatch(RestartApp())
+                      onPressed: ()  => {BlocProvider.of<AuthenticationBloc>(context).add(ClickedLogout()),
+                      configBloc.add(RestartApp())
                       },
                       shape: RoundedRectangleBorder(
                           borderRadius: new BorderRadius.circular(30.0))),
@@ -312,6 +312,6 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Future pickImage() async {
     profileImageFile = await ImagePicker.pickImage(source: ImageSource.gallery);
-    configBloc.dispatch(UpdateProfilePicture(profileImageFile));
+    configBloc.add(UpdateProfilePicture(profileImageFile));
   }
 }

--- a/lib/pages/SingleConversationPage.dart
+++ b/lib/pages/SingleConversationPage.dart
@@ -31,7 +31,7 @@ class _SingleConversationPageState extends State<SingleConversationPage>
   @override
   void initState() {
     chatBloc = BlocProvider.of<ChatBloc>(context);
-    chatBloc.dispatch(RegisterActiveChatEvent(contact.chatId));
+    chatBloc.add(RegisterActiveChatEvent(contact.chatId));
     super.initState();
   }
 

--- a/lib/providers/ChatProvider.dart
+++ b/lib/providers/ChatProvider.dart
@@ -105,9 +105,9 @@ class ChatProvider extends BaseChatProvider {
         .document(prevMessage.documentId)
         .get(); // gets a reference to the last message in the existing list
     final querySnapshot = await messagesCollection
+        .orderBy('timeStamp', descending: true) // order them by timestamp
         .startAfterDocument(
         prevDocument) // Start reading documents after the specified document
-        .orderBy('timeStamp', descending: true) // order them by timestamp
         .limit(20) // limit the read to 20 items
         .getDocuments();
     List<Message> messageList = List();

--- a/lib/widgets/ChatAppBar.dart
+++ b/lib/widgets/ChatAppBar.dart
@@ -259,7 +259,7 @@ class _ChatAppBarState extends State<ChatAppBar> {
       file = await FilePicker.getFile(type: fileType);
     
     if (file == null) return;
-    chatBloc.dispatch(SendAttachmentEvent(chat.chatId, file, fileType));
+    chatBloc.add(SendAttachmentEvent(chat.chatId, file, fileType));
     Navigator.pop(context);
     GradientSnackBar.showMessage(context, 'Sending attachment..');
   }

--- a/lib/widgets/ChatListWidget.dart
+++ b/lib/widgets/ChatListWidget.dart
@@ -30,7 +30,7 @@ class _ChatListWidgetState extends State<ChatListWidget> {
       double currentScroll = listScrollController.position.pixels;
       if (maxScroll == currentScroll) {
         BlocProvider.of<ChatBloc>(context)
-            .dispatch(FetchPreviousMessagesEvent(this.chat,messages.last));
+            .add(FetchPreviousMessagesEvent(this.chat,messages.last));
       }
     });
   }

--- a/lib/widgets/ConversationListWidget.dart
+++ b/lib/widgets/ConversationListWidget.dart
@@ -16,7 +16,7 @@ class _ConversationListWidgetState extends State<ConversationListWidget> {
   @override
   void initState() {
     homeBloc = BlocProvider.of<HomeBloc>(context);
-    homeBloc.dispatch(FetchHomeChatsEvent());
+    homeBloc.add(FetchHomeChatsEvent());
     super.initState();
   }
 

--- a/lib/widgets/InputWidget.dart
+++ b/lib/widgets/InputWidget.dart
@@ -31,7 +31,7 @@ class _InputWidgetState extends State<InputWidget>{
                       child: IconButton(
                         icon: Icon(Icons.face),
                         color: Theme.of(context).accentColor,
-                        onPressed: () =>chatBloc.dispatch(ToggleEmojiKeyboardEvent(!showEmojiKeyboard)),
+                        onPressed: () =>chatBloc.add(ToggleEmojiKeyboardEvent(!showEmojiKeyboard)),
                       ),
                     ),
                     color: Theme.of(context).primaryColor,
@@ -99,7 +99,7 @@ class _InputWidgetState extends State<InputWidget>{
   void sendMessage(context) {
     if(textEditingController.text.isEmpty)
       return;
-    chatBloc.dispatch(SendTextMessageEvent(textEditingController.text));
+    chatBloc.add(SendTextMessageEvent(textEditingController.text));
     textEditingController.clear();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,56 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.13"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.1"
   bloc:
     dependency: transitive
     description:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.0"
+    version: "4.0.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   cached_network_image:
     dependency: "direct main"
     description:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.2.0+1"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   cloud_firestore:
     dependency: "direct main"
     description:
@@ -63,7 +70,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.14.12"
   convert:
     dependency: transitive
     description:
@@ -77,7 +84,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -113,6 +120,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.0"
   file_picker:
     dependency: "direct main"
     description:
@@ -159,14 +173,14 @@ packages:
       name: flutter_bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.21.0"
+    version: "4.0.0"
   flutter_cache_manager:
     dependency: transitive
     description:
       name: flutter_cache_manager
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.0"
   flutter_downloader:
     dependency: "direct main"
     description:
@@ -213,7 +227,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.12"
   image_picker:
     dependency: "direct main"
     description:
@@ -241,14 +255,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.6"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.8"
   mockito:
     dependency: "direct dev"
     description:
@@ -256,27 +270,55 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.4"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.6.10"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+1"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4+3"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.9.0"
   petitparser:
     dependency: transitive
     description:
@@ -291,27 +333,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.13"
   provider:
     dependency: transitive
     description:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "4.1.2"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.3"
   rxdart:
     dependency: transitive
     description:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.22.2"
+    version: "0.24.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -330,14 +386,21 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.7.0"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6+5"
+    version: "1.3.0+2"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   stack_trace:
     dependency: transitive
     description:
@@ -358,7 +421,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   synchronized:
     dependency: transitive
     description:
@@ -379,7 +442,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.15"
   typed_data:
     dependency: transitive
     description:
@@ -408,13 +471,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.2+1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   xml:
     dependency: transitive
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.1"
   yaml:
     dependency: transitive
     description:
@@ -423,5 +493,5 @@ packages:
     source: hosted
     version: "2.1.16"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
-  flutter: ">=1.5.0 <2.0.0"
+  dart: ">=2.7.0 <3.0.0"
+  flutter: ">=1.16.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   infinite_listview: ^1.0.0
   firebase_auth: ^0.14.0+4 #to auth with firebase
   google_sign_in: ^4.0.7 #to auth with google account
-  flutter_bloc: ^0.21.0 #heedelps in implementing blocs
+  flutter_bloc: ^4.0.0 #heedelps in implementing blocs
   equatable: ^0.5.0 #helps in comparing class using their values
   cloud_firestore: ^0.12.9+1 #Firebase Database
   image_picker: ^0.6.1+4 #image picker used for picking images from gallery
@@ -38,7 +38,7 @@ dependencies:
   downloads_path_provider: ^0.1.0
   flushbar: ^1.9.0
   path_provider: ^1.3.0
-  cached_network_image: ^1.1.1
+  cached_network_image: ^2.2.0
 
 dev_dependencies:
   flutter_test:

--- a/test/blocs/AuthenticationBloc_test.dart
+++ b/test/blocs/AuthenticationBloc_test.dart
@@ -53,7 +53,7 @@ void main() {
       ];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
 
-      authenticationBloc.dispatch(AppLaunched());
+      authenticationBloc.add(AppLaunched());
     });
     test('emits [Uninitialized -> ProfileUpdated] when user is logged in and profile is complete', () {
       when(authenticationRepository.isLoggedIn())
@@ -69,7 +69,7 @@ void main() {
       ];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
 
-      authenticationBloc.dispatch(AppLaunched());
+      authenticationBloc.add(AppLaunched());
     });
     test('emits [Uninitialized -> AuthInProgress -> Authenticated -> ProfileUpdateInProgress -> PreFillData] when user is logged in and profile is not complete', () {
       when(authenticationRepository.isLoggedIn())
@@ -87,7 +87,7 @@ void main() {
       ];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
 
-      authenticationBloc.dispatch(AppLaunched());
+      authenticationBloc.add(AppLaunched());
     });
   });
 
@@ -103,7 +103,7 @@ void main() {
         ProfileUpdated()
       ];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
-      authenticationBloc.dispatch(ClickedGoogleLogin());
+      authenticationBloc.add(ClickedGoogleLogin());
     });
 
     test('emits [AuthInProgress -> Authenticated -> ProfileUpdateInProgress -> PreFillData] when the user clicks Google Login button and after login result, the profile is found to be incomplete', () {
@@ -119,7 +119,7 @@ void main() {
         PreFillData(user)
       ];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
-      authenticationBloc.dispatch(ClickedGoogleLogin());
+      authenticationBloc.add(ClickedGoogleLogin());
     });
   });
 
@@ -134,7 +134,7 @@ void main() {
       ];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
 
-      authenticationBloc.dispatch(LoggedIn(firebaseUser));
+      authenticationBloc.add(LoggedIn(firebaseUser));
     });
   });
 
@@ -142,7 +142,7 @@ void main() {
     test('emits [ReceivedProfilePicture] everytime', () {
       final expectedStates = [Uninitialized(), ReceivedProfilePicture(file)];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
-      authenticationBloc.dispatch(PickedProfilePicture(file));
+      authenticationBloc.add(PickedProfilePicture(file));
     });
   });
 
@@ -160,7 +160,7 @@ void main() {
         ProfileUpdated()
       ];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
-      authenticationBloc.dispatch(SaveProfile(file, age, username));
+      authenticationBloc.add(SaveProfile(file, age, username));
     });
   });
 
@@ -168,7 +168,7 @@ void main() {
     test('emits [UnAuthenticated] when clicked logout', () {
       final expectedStates = [Uninitialized(), UnAuthenticated()];
       expectLater(authenticationBloc.state, emitsInOrder(expectedStates));
-      authenticationBloc.dispatch(ClickedLogout());
+      authenticationBloc.add(ClickedLogout());
     });
   });
 
@@ -177,6 +177,6 @@ void main() {
       authenticationBloc.state,
       emitsInOrder([]),
     );
-    authenticationBloc.dispose();
+    authenticationBloc.close();
   });
 }


### PR DESCRIPTION
Main fix is fixing the pagination of messages so that the ordering of messages is called prior to the startAtDocument function. Also had to update the dependencies because cached_network_image dependency was breaking on 1.17.2. Updating it to 2.2.0 also forced me to update flutter_bloc to 4.0.0, which led to the refactor of all the `dispatch` calls to `add` calls.